### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a reproducible problem.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the issue.
+      placeholder: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Include exact steps so we can reproduce the issue.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, app version, commit SHA, etc.
+      placeholder: Ubuntu 24.04, Bun 1.2.x, Chrome 122
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: Paste logs or add screenshots to help debugging.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,59 +1,32 @@
 name: Bug report
-description: Report a reproducible problem.
-title: "[Bug]: "
+description: Report a bug.
+title: "[Bug] "
 labels:
   - bug
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to file a bug report.
   - type: textarea
-    id: summary
+    id: bug
     attributes:
-      label: Summary
-      description: Briefly describe the issue.
-      placeholder: What happened?
+      label: What happened?
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
       label: Steps to reproduce
-      description: Include exact steps so we can reproduce the issue.
       placeholder: |
-        1. Go to ...
-        2. Click ...
-        3. See error ...
+        1. ...
+        2. ...
+        3. ...
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
-      description: What did you expect to happen?
-    validations:
-      required: true
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual behavior
-      description: What actually happened?
     validations:
       required: true
   - type: input
-    id: environment
+    id: env
     attributes:
       label: Environment
-      description: Browser, OS, app version, commit SHA, etc.
-      placeholder: Ubuntu 24.04, Bun 1.2.x, Chrome 122
-    validations:
-      required: false
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant logs or screenshots
-      description: Paste logs or add screenshots to help debugging.
-      render: shell
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest an idea to improve the project.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing your idea.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: It is currently difficult to ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the change you would like to see.
+      placeholder: I would like a way to ...
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you considered.
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Links, mockups, or examples from other projects.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,40 +1,22 @@
 name: Feature request
-description: Suggest an idea to improve the project.
-title: "[Feature]: "
+description: Suggest an improvement.
+title: "[Feature] "
 labels:
   - enhancement
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for sharing your idea.
   - type: textarea
     id: problem
     attributes:
-      label: Problem statement
-      description: What problem are you trying to solve?
-      placeholder: It is currently difficult to ...
+      label: Problem
     validations:
       required: true
   - type: textarea
-    id: proposal
+    id: solution
     attributes:
       label: Proposed solution
-      description: Describe the change you would like to see.
-      placeholder: I would like a way to ...
     validations:
       required: true
   - type: textarea
-    id: alternatives
+    id: context
     attributes:
-      label: Alternatives considered
-      description: Any other approaches you considered.
-    validations:
-      required: false
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional context
-      description: Links, mockups, or examples from other projects.
-    validations:
-      required: false
+      label: Extra context


### PR DESCRIPTION
## Summary
- add GitHub issue forms for bug reports and feature requests
- disable blank issues to route submissions through structured templates
- include repro, expected/actual behavior, and context fields for better triage